### PR TITLE
Hotfix/Request Removal from Queue if the same is being skipped.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ plugins {
 apply plugin: 'com.android.library'
 
 //  Versions are x.y.z and version code is xxyyzz.  Leading 0s are stripped.
-version = "0.2.1"
-def versionNum = 201
+version = "0.2.2"
+def versionNum = 202
 
 android {
     compileSdkVersion 29

--- a/src/main/java/com/hiqes/andele/Andele.java
+++ b/src/main/java/com/hiqes/andele/Andele.java
@@ -761,10 +761,15 @@ public class Andele {
                         }
                     }
 
-                    //  If we get here, there were no more permissions to show
-                    //  education info about, so do the request.
                     if (!skipAsk) {
+                        //  If we get here, there were no more permissions to show
+                        //  education info about, so do the request.
                         doRequest(msg.arg1);
+                    } else {
+                        //  As we are skipping to ask the user for the permission
+                        //  because the user is not interested when educated,
+                        //  we must remove the request from the active requests queue
+                        sReqMgr.removeRequest(msg.arg1);
                     }
 
                     break;


### PR DESCRIPTION
**Description**
For OPTIONAL type permission, When an edu dialog is being shown, based on the user input, the existing request inside the queue should be removed if in any way we are skipping to ask the user about the permission.

**Tests Performed**
Tested with "demompermissions"

**Reviewer Focus**
Everything

**Conditions for Merge**
Approval from Larry.